### PR TITLE
feat: modules/cloud — AWS, GCP, Azure aliases and functions

### DIFF
--- a/modules/cloud/aliases.sh
+++ b/modules/cloud/aliases.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# modules/cloud/aliases.sh — Cloud CLI aliases
+
+dotfiles_section "cloud.aws" && {
+    if command -v aws &>/dev/null; then
+        alias awsp='aws_profile'
+        alias awsr='aws_region'
+        alias awsi='aws sts get-caller-identity'
+    fi
+}
+
+dotfiles_section "cloud.gcp" && {
+    if command -v gcloud &>/dev/null; then
+        alias gci='gcloud info'
+        alias gcl='gcloud config list'
+        alias gcp='gcloud config set project'
+        alias gcr='gcloud config set compute/region'
+    fi
+}
+
+dotfiles_section "cloud.azure" && {
+    if command -v az &>/dev/null; then
+        alias azi='az account show'
+        alias azl='az account list --output table'
+        alias azs='az account set --subscription'
+    fi
+}

--- a/modules/cloud/functions.sh
+++ b/modules/cloud/functions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# modules/cloud/functions.sh — Cloud helper functions
+
+dotfiles_section "cloud.aws" && {
+    # Switch AWS profile
+    aws_profile() {
+        if [[ -z "$1" ]]; then
+            echo "Available AWS profiles:"
+            aws configure list-profiles 2>/dev/null | while read -r p; do
+                if [[ "$AWS_PROFILE" == "$p" ]]; then
+                    echo "* $p (current)"
+                else
+                    echo "  $p"
+                fi
+            done
+            return 0
+        fi
+        export AWS_PROFILE="$1"
+        echo "Switched to AWS profile: $1"
+    }
+
+    # Switch AWS region
+    aws_region() {
+        if [[ -z "$1" ]]; then
+            echo "Current: ${AWS_REGION:-<not set>}"
+            echo "Usage: aws_region <region>"
+            return 0
+        fi
+        export AWS_REGION="$1"
+        export AWS_DEFAULT_REGION="$1"
+        echo "Switched to AWS region: $1"
+    }
+
+    # ECR login
+    docker_login_ecr() {
+        local region="${1:-${AWS_REGION:-us-east-1}}"
+        local account_id
+        account_id=$(aws sts get-caller-identity --query Account --output text 2>/dev/null)
+        [[ -z "$account_id" ]] && { echo "Could not detect AWS account ID"; return 1; }
+        local registry="${account_id}.dkr.ecr.${region}.amazonaws.com"
+        aws ecr get-login-password --region "$region" | docker login --username AWS --password-stdin "$registry"
+    }
+}
+
+dotfiles_section "cloud.gcp" && {
+    # GCR login
+    docker_login_gcr() {
+        command -v gcloud &>/dev/null || { echo "gcloud not installed"; return 1; }
+        gcloud auth configure-docker
+    }
+}

--- a/modules/cloud/module.json
+++ b/modules/cloud/module.json
@@ -1,0 +1,23 @@
+{
+  "name": "cloud",
+  "version": "1.0.0",
+  "description": "Cloud CLI aliases and helper functions (AWS, GCP, Azure)",
+  "sections": {
+    "cloud.aws": "AWS CLI aliases and helpers",
+    "cloud.gcp": "GCP/gcloud aliases and helpers",
+    "cloud.azure": "Azure CLI aliases and helpers"
+  },
+  "shell": {
+    "load_order": ["aliases.sh", "functions.sh"]
+  },
+  "install": {
+    "macos": {
+      "brew": ["awscli", "google-cloud-sdk", "azure-cli"]
+    },
+    "linux": {
+      "apt": ["awscli"],
+      "snap": ["google-cloud-cli --classic"]
+    },
+    "wsl": { "inherit": "linux" }
+  }
+}


### PR DESCRIPTION
## Summary
- 3 sections: aws, gcp, azure — users enable only what they need
- **AWS**: profile/region switching, ECR login, identity check
- **GCP**: gcloud config aliases, GCR login
- **Azure**: account management aliases
- Install recipes for brew, apt, snap

Closes #17