### PR TITLE
feat: modules/kubernetes — kubectl, helm, context switching

### DIFF
--- a/modules/kubernetes/aliases.sh
+++ b/modules/kubernetes/aliases.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# modules/kubernetes/aliases.sh — Kubernetes aliases
+
+dotfiles_section "kubernetes.core" && {
+    if command -v kubectl &>/dev/null; then
+        alias k="kubectl"
+        alias kgp="kubectl get pods"
+        alias kgs="kubectl get services"
+        alias kgd="kubectl get deployments"
+        alias kgn="kubectl get nodes"
+        alias kaf="kubectl apply -f"
+        alias kdel="kubectl delete"
+        alias klog="kubectl logs -f"
+        alias kexec="kubectl exec -it"
+        alias kdesc="kubectl describe"
+    fi
+}
+
+dotfiles_section "kubernetes.helm" && {
+    if command -v helm &>/dev/null; then
+        alias h="helm"
+        alias hi="helm install"
+        alias hu="helm upgrade"
+        alias hl="helm list"
+        alias hs="helm search repo"
+        alias hr="helm repo"
+    fi
+}
+
+dotfiles_section "kubernetes.ctx" && {
+    if command -v kubectx &>/dev/null; then
+        alias kctx="kubectx"
+        alias kns="kubens"
+    elif command -v kubectl &>/dev/null; then
+        alias kctx="kubectl config use-context"
+        alias kns="kubectl config set-context --current --namespace"
+    fi
+}

--- a/modules/kubernetes/completions.sh
+++ b/modules/kubernetes/completions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# modules/kubernetes/completions.sh — Kubernetes tab completion
+
+dotfiles_section "kubernetes.core" && {
+    if command -v kubectl &>/dev/null; then
+        eval "$(kubectl completion bash 2>/dev/null)"
+        complete -F __start_kubectl k 2>/dev/null
+    fi
+}
+
+dotfiles_section "kubernetes.helm" && {
+    if command -v helm &>/dev/null; then
+        eval "$(helm completion bash 2>/dev/null)"
+    fi
+}

--- a/modules/kubernetes/module.json
+++ b/modules/kubernetes/module.json
@@ -1,0 +1,24 @@
+{
+  "name": "kubernetes",
+  "version": "1.0.0",
+  "description": "Kubernetes CLI tools, aliases, and shell helpers",
+  "dependencies": ["containers"],
+  "sections": {
+    "kubernetes.core": "Base kubectl aliases and functions",
+    "kubernetes.helm": "Helm package manager aliases",
+    "kubernetes.ctx": "Context and namespace switching helpers"
+  },
+  "shell": {
+    "load_order": ["aliases.sh", "completions.sh"]
+  },
+  "install": {
+    "macos": {
+      "brew": ["kubectl", "helm", "kubectx"]
+    },
+    "linux": {
+      "apt": ["kubectl"],
+      "snap": ["helm --classic", "kubectl --classic"]
+    },
+    "wsl": { "inherit": "linux" }
+  }
+}


### PR DESCRIPTION
## Summary
- 3 sections: core (kubectl), helm, ctx (kubectx/kubens with fallbacks)
- Tab completion for kubectl and helm
- Depends on containers module
- Install recipes for brew, apt, snap

Closes #16