### PR TITLE
feat: extract remaining 12 modules (python, node, rust, vim, tmux, fzf, terraform, navigation, safety, network, security, system)

### DIFF
--- a/modules/fzf/exports.sh
+++ b/modules/fzf/exports.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+dotfiles_section "fzf.core" && {
+    if command -v fzf &>/dev/null; then
+        export FZF_DEFAULT_OPTS='
+            --height 40%
+            --layout=reverse
+            --border
+            --inline-info
+            --color=dark
+            --color=fg:-1,bg:-1,hl:#5fff87,fg+:-1,bg+:-1,hl+:#ffaf5f
+            --color=info:#af87ff,prompt:#5fff87,pointer:#ff87d7,marker:#ff87d7,spinner:#ff87d7
+        '
+
+        # Use fd or ripgrep for better performance
+        if command -v fd &>/dev/null; then
+            export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
+            export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+        elif command -v fdfind &>/dev/null; then
+            export FZF_DEFAULT_COMMAND='fdfind --type f --hidden --follow --exclude .git'
+            export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+        elif command -v rg &>/dev/null; then
+            export FZF_DEFAULT_COMMAND='rg --files --hidden --follow --glob "!.git/*"'
+            export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+        fi
+    fi
+}
+
+dotfiles_section "fzf.keybindings" && {
+    # Source fzf keybindings and completion if available
+    if [[ -f "${HOMEBREW_PREFIX:-}/opt/fzf/shell/key-bindings.bash" ]]; then
+        . "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.bash"
+        . "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.bash"
+    elif [[ -f "/usr/share/doc/fzf/examples/key-bindings.bash" ]]; then
+        . "/usr/share/doc/fzf/examples/key-bindings.bash"
+        [[ -f "/usr/share/bash-completion/completions/fzf" ]] && . "/usr/share/bash-completion/completions/fzf"
+    fi
+}

--- a/modules/fzf/module.json
+++ b/modules/fzf/module.json
@@ -1,0 +1,17 @@
+{
+  "name": "fzf",
+  "version": "1.0.0",
+  "description": "Fuzzy finder configuration and keybindings",
+  "sections": {
+    "fzf.core": "FZF default options and commands",
+    "fzf.keybindings": "Shell keybindings (Ctrl-T, Ctrl-R, Alt-C)"
+  },
+  "shell": {
+    "load_order": ["exports.sh"]
+  },
+  "install": {
+    "macos": { "brew": ["fzf"] },
+    "linux": { "apt": ["fzf"] },
+    "wsl": { "inherit": "linux" }
+  }
+}

--- a/modules/navigation/aliases.sh
+++ b/modules/navigation/aliases.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+dotfiles_section "navigation.dirs" && {
+    alias dl="cd ~/Downloads"
+    alias dt="cd ~/Desktop"
+    alias p="cd ~/code"
+}

--- a/modules/navigation/module.json
+++ b/modules/navigation/module.json
@@ -1,0 +1,12 @@
+{
+  "name": "navigation",
+  "version": "1.0.0",
+  "description": "Directory navigation shortcuts and bookmarks",
+  "sections": {
+    "navigation.dirs": "Common directory shortcuts",
+    "navigation.bookmarks": "Directory bookmarking"
+  },
+  "shell": {
+    "load_order": ["aliases.sh"]
+  }
+}

--- a/modules/network/aliases.sh
+++ b/modules/network/aliases.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+dotfiles_section "network.ip" && {
+    alias myip="dig +short myip.opendns.com @resolver1.opendns.com"
+    alias ipinfo="curl -s ipinfo.io"
+    alias weather="curl -s wttr.in | head -n 17"
+}

--- a/modules/network/functions.sh
+++ b/modules/network/functions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+dotfiles_section "network.ip" && {
+    # Test internet connectivity
+    testnet() {
+        echo "Testing connectivity..."
+        ping -c 1 8.8.8.8 &>/dev/null && echo "Internet: reachable" || echo "Internet: unreachable"
+        ping -c 1 google.com &>/dev/null && echo "DNS: working" || echo "DNS: failed"
+    }
+
+    # Quick port check
+    port() {
+        [[ -z "$1" ]] && { echo "Usage: port <number>"; return 1; }
+        if is_macos; then
+            lsof -i ":$1"
+        else
+            ss -tlnp | grep ":$1"
+        fi
+    }
+}
+
+dotfiles_section "network.http" && {
+    # Show SSL certificate names for a domain
+    getcertnames() {
+        [[ -z "$1" ]] && { echo "Usage: getcertnames <domain>"; return 1; }
+        echo "Testing $1..."
+        local tmp
+        tmp=$(echo -e "GET / HTTP/1.0\nEOT" | openssl s_client -connect "$1:443" -servername "$1" 2>&1)
+        if [[ "$tmp" == *"-----BEGIN CERTIFICATE-----"* ]]; then
+            echo "$tmp" | openssl x509 -text -certopt "no_aux,no_header,no_issuer,no_pubkey,no_serial,no_sigdump,no_signame,no_validity,no_version" | grep -A1 "Subject Alternative Name:" | tail -1 | tr ',' '\n' | sed 's/DNS://g; s/ //g'
+        else
+            echo "Certificate not found"
+            return 1
+        fi
+    }
+
+    # DNS dig shortcut
+    digga() {
+        dig +nocmd "$1" any +multiline +noall +answer
+    }
+}

--- a/modules/network/module.json
+++ b/modules/network/module.json
@@ -1,0 +1,12 @@
+{
+  "name": "network",
+  "version": "1.0.0",
+  "description": "Network diagnostic aliases and functions",
+  "sections": {
+    "network.ip": "IP address and connectivity checks",
+    "network.http": "HTTP traffic and certificate inspection"
+  },
+  "shell": {
+    "load_order": ["aliases.sh", "functions.sh"]
+  }
+}

--- a/modules/node/aliases.sh
+++ b/modules/node/aliases.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+dotfiles_section "node.npm" && {
+    alias ni="npm install"
+    alias ns="npm start"
+    alias nt="npm test"
+    alias nr="npm run"
+    alias nb="npm run build"
+    alias nd="npm run dev"
+}

--- a/modules/node/exports.sh
+++ b/modules/node/exports.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+dotfiles_section "node.npm" && {
+    export NODE_REPL_HISTORY="$HOME/.node_history"
+    export NODE_REPL_HISTORY_SIZE='32768'
+    export NODE_REPL_MODE='sloppy'
+}

--- a/modules/node/module.json
+++ b/modules/node/module.json
@@ -1,0 +1,17 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "description": "Node.js and npm aliases",
+  "sections": {
+    "node.npm": "npm command shortcuts",
+    "node.scripts": "Common script runners"
+  },
+  "shell": {
+    "load_order": ["exports.sh", "aliases.sh"]
+  },
+  "install": {
+    "macos": { "brew": ["node"] },
+    "linux": { "apt": ["nodejs", "npm"] },
+    "wsl": { "inherit": "linux" }
+  }
+}

--- a/modules/python/aliases.sh
+++ b/modules/python/aliases.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+dotfiles_section "python.core" && {
+    alias py="python3"
+    alias pip="pip3"
+}
+
+dotfiles_section "python.venv" && {
+    alias venv="python3 -m venv"
+    alias activate="source venv/bin/activate 2>/dev/null || source .venv/bin/activate"
+}

--- a/modules/python/exports.sh
+++ b/modules/python/exports.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+dotfiles_section "python.core" && {
+    export PYTHONIOENCODING='UTF-8'
+    export PYTHONDONTWRITEBYTECODE=1
+    export PYTHONUNBUFFERED=1
+}

--- a/modules/python/module.json
+++ b/modules/python/module.json
@@ -1,0 +1,17 @@
+{
+  "name": "python",
+  "version": "1.0.0",
+  "description": "Python development aliases and environment setup",
+  "sections": {
+    "python.core": "Python command aliases",
+    "python.venv": "Virtual environment helpers"
+  },
+  "shell": {
+    "load_order": ["exports.sh", "aliases.sh"]
+  },
+  "install": {
+    "macos": { "brew": ["python@3"] },
+    "linux": { "apt": ["python3", "python3-pip", "python3-venv"] },
+    "wsl": { "inherit": "linux" }
+  }
+}

--- a/modules/rust/aliases.sh
+++ b/modules/rust/aliases.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+dotfiles_section "rust.cargo" && {
+    if command -v cargo &>/dev/null; then
+        alias cb="cargo build"
+        alias cr="cargo run"
+        alias ct="cargo test"
+        alias cc="cargo check"
+        alias cf="cargo fmt"
+        alias cl="cargo clippy"
+    fi
+}

--- a/modules/rust/module.json
+++ b/modules/rust/module.json
@@ -1,0 +1,11 @@
+{
+  "name": "rust",
+  "version": "1.0.0",
+  "description": "Rust and Cargo aliases",
+  "sections": {
+    "rust.cargo": "Cargo command shortcuts"
+  },
+  "shell": {
+    "load_order": ["path.sh", "aliases.sh"]
+  }
+}

--- a/modules/rust/path.sh
+++ b/modules/rust/path.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+dotfiles_section "rust.cargo" && {
+    add_to_path "${HOME}/.cargo/bin"
+}

--- a/modules/safety/aliases.sh
+++ b/modules/safety/aliases.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Note: basic rm/cp/mv safety is in core/aliases.sh
+# This module adds disk-awareness aliases
+
+dotfiles_section "safety.disk" && {
+    alias diskspace="df -h | grep -v tmpfs | sort -k5 -h -r"
+    alias dirsize="du -sh * 2>/dev/null | sort -h -r"
+    alias biggest="du -ah . 2>/dev/null | sort -rh | head -20"
+}

--- a/modules/safety/module.json
+++ b/modules/safety/module.json
@@ -1,0 +1,12 @@
+{
+  "name": "safety",
+  "version": "1.0.0",
+  "description": "Safe defaults and disk usage helpers",
+  "sections": {
+    "safety.interactive": "Interactive mode for destructive commands",
+    "safety.disk": "Disk usage and cleanup helpers"
+  },
+  "shell": {
+    "load_order": ["aliases.sh"]
+  }
+}

--- a/modules/security/functions.sh
+++ b/modules/security/functions.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+dotfiles_section "security.ssh" && {
+    # Generate SSH key
+    ssh_keygen() {
+        local email="$1" key_type="${2:-ed25519}"
+        [[ -z "$email" ]] && { echo "Usage: ssh_keygen <email> [key_type]"; return 1; }
+        local key_file="$HOME/.ssh/id_${key_type}"
+        ssh-keygen -t "$key_type" -C "$email" -f "$key_file"
+    }
+
+    # Add SSH key to agent
+    ssh_add() {
+        [[ -z "$SSH_AUTH_SOCK" ]] && eval "$(ssh-agent -s)"
+        if [[ -n "$1" ]]; then
+            ssh-add "$1"
+        else
+            local keys=($(find ~/.ssh -type f -name 'id_*' ! -name '*.pub' 2>/dev/null))
+            [[ ${#keys[@]} -eq 0 ]] && { echo "No SSH keys found"; return 1; }
+            ssh-add "${keys[0]}"
+        fi
+    }
+
+    # Copy SSH public key to clipboard
+    ssh_copy() {
+        local key="${1:-$(find ~/.ssh -name 'id_*.pub' 2>/dev/null | head -1)}"
+        [[ ! -f "$key" ]] && { echo "No public key found"; return 1; }
+        if command -v pbcopy &>/dev/null; then
+            cat "$key" | pbcopy
+        elif command -v xclip &>/dev/null; then
+            cat "$key" | xclip -selection clipboard
+        elif command -v clip.exe &>/dev/null; then
+            cat "$key" | clip.exe
+        else
+            cat "$key"
+            return 0
+        fi
+        echo "Public key copied to clipboard: $key"
+    }
+
+    # List SSH keys
+    ssh_list() {
+        echo "SSH Keys:"
+        for key in ~/.ssh/id_*.pub; do
+            [[ -f "$key" ]] || continue
+            ssh-keygen -lf "$key" 2>/dev/null
+        done
+        echo ""
+        echo "Loaded in agent:"
+        ssh-add -l 2>/dev/null || echo "  (none)"
+    }
+
+    # Check SSH permissions
+    ssh_check() {
+        local issues=0
+        [[ -d "$HOME/.ssh" ]] || { echo "~/.ssh doesn't exist"; return 0; }
+        local perms
+        perms=$(stat -c '%a' "$HOME/.ssh" 2>/dev/null || stat -f '%A' "$HOME/.ssh")
+        [[ "$perms" != "700" ]] && { echo "~/.ssh: $perms (should be 700)"; issues=$((issues+1)); }
+        for key in ~/.ssh/id_*; do
+            [[ -f "$key" && ! "$key" =~ \.pub$ ]] || continue
+            perms=$(stat -c '%a' "$key" 2>/dev/null || stat -f '%A' "$key")
+            [[ "$perms" != "600" ]] && { echo "$(basename $key): $perms (should be 600)"; issues=$((issues+1)); }
+        done
+        [[ $issues -eq 0 ]] && echo "All SSH permissions OK" || echo "$issues issue(s) found"
+    }
+
+    # Fix SSH permissions
+    ssh_fix() {
+        [[ -d "$HOME/.ssh" ]] && chmod 700 "$HOME/.ssh"
+        for key in ~/.ssh/id_*; do
+            [[ -f "$key" && ! "$key" =~ \.pub$ ]] && chmod 600 "$key"
+            [[ -f "$key" && "$key" =~ \.pub$ ]] && chmod 644 "$key"
+        done
+        [[ -f "$HOME/.ssh/config" ]] && chmod 600 "$HOME/.ssh/config"
+        [[ -f "$HOME/.ssh/authorized_keys" ]] && chmod 600 "$HOME/.ssh/authorized_keys"
+        echo "SSH permissions fixed"
+    }
+
+    # Password generator
+    genpass() {
+        local length="${1:-16}"
+        if command -v openssl &>/dev/null; then
+            openssl rand -base64 "$length" | tr -d '\n' | head -c "$length"
+        else
+            < /dev/urandom tr -dc A-Za-z0-9 | head -c"$length"
+        fi
+        echo
+    }
+}
+
+dotfiles_section "security.gpg" && {
+    # List GPG keys
+    gpg_list() {
+        command -v gpg &>/dev/null || { echo "GPG not installed"; return 1; }
+        gpg --list-secret-keys --keyid-format=long
+    }
+
+    # Export GPG public key
+    gpg_export() {
+        [[ -z "$1" ]] && { echo "Usage: gpg_export <email>"; return 1; }
+        gpg --armor --export "$1"
+    }
+
+    # Configure git to use GPG key
+    gpg_git() {
+        [[ -z "$1" ]] && { echo "Usage: gpg_git <email>"; return 1; }
+        local key_id
+        key_id=$(gpg --list-secret-keys --keyid-format=long "$1" 2>/dev/null | grep sec | awk '{print $2}' | cut -d'/' -f2)
+        [[ -z "$key_id" ]] && { echo "No GPG key found for $1"; return 1; }
+        git config --global user.signingkey "$key_id"
+        git config --global commit.gpgsign true
+        echo "Git configured to sign with key: $key_id"
+    }
+}

--- a/modules/security/module.json
+++ b/modules/security/module.json
@@ -1,0 +1,12 @@
+{
+  "name": "security",
+  "version": "1.0.0",
+  "description": "SSH and GPG key management functions",
+  "sections": {
+    "security.ssh": "SSH key generation, management, and permission checking",
+    "security.gpg": "GPG key generation and git signing setup"
+  },
+  "shell": {
+    "load_order": ["functions.sh"]
+  }
+}

--- a/modules/system/aliases.sh
+++ b/modules/system/aliases.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+dotfiles_section "system.info" && {
+    alias week='date +%V'
+    alias now='date +"%T"'
+    alias nowdate='date +"%Y-%m-%d"'
+}
+
+dotfiles_section "system.processes" && {
+    if command -v htop &>/dev/null; then
+        alias top="htop"
+    fi
+    alias free="free -h"
+}

--- a/modules/system/functions.sh
+++ b/modules/system/functions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+dotfiles_section "system.info" && {
+    sysinfo() {
+        echo "System Information:"
+        if is_macos; then
+            echo "  OS: macOS $(sw_vers -productVersion)"
+            echo "  CPU: $(sysctl -n machdep.cpu.brand_string)"
+            echo "  Memory: $(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 )) GB"
+        elif is_linux; then
+            echo "  OS: $(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"')"
+            echo "  CPU: $(lscpu 2>/dev/null | grep 'Model name' | cut -d: -f2 | xargs)"
+            echo "  Memory: $(free -h 2>/dev/null | awk '/^Mem:/{print $2}')"
+        fi
+        echo "  Kernel: $(uname -r)"
+        echo "  Arch: $(uname -m)"
+        echo "  Uptime: $(uptime -p 2>/dev/null || uptime)"
+    }
+
+    # Quick calculator
+    calc() { echo "$*" | bc -l; }
+}

--- a/modules/system/module.json
+++ b/modules/system/module.json
@@ -1,0 +1,12 @@
+{
+  "name": "system",
+  "version": "1.0.0",
+  "description": "System information and process management",
+  "sections": {
+    "system.info": "System information display",
+    "system.processes": "Process management helpers"
+  },
+  "shell": {
+    "load_order": ["aliases.sh", "functions.sh"]
+  }
+}

--- a/modules/terraform/aliases.sh
+++ b/modules/terraform/aliases.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+dotfiles_section "terraform.core" && {
+    if command -v terraform &>/dev/null; then
+        alias tf="terraform"
+        alias tfi="terraform init"
+        alias tfp="terraform plan"
+        alias tfa="terraform apply"
+        alias tfd="terraform destroy"
+        alias tfv="terraform validate"
+        alias tff="terraform fmt"
+        alias tfs="terraform state"
+    elif command -v tofu &>/dev/null; then
+        alias tf="tofu"
+        alias tfi="tofu init"
+        alias tfp="tofu plan"
+        alias tfa="tofu apply"
+        alias tfd="tofu destroy"
+        alias tfv="tofu validate"
+        alias tff="tofu fmt"
+        alias tfs="tofu state"
+    fi
+}

--- a/modules/terraform/module.json
+++ b/modules/terraform/module.json
@@ -1,0 +1,16 @@
+{
+  "name": "terraform",
+  "version": "1.0.0",
+  "description": "Terraform/OpenTofu aliases",
+  "sections": {
+    "terraform.core": "Terraform command shortcuts"
+  },
+  "shell": {
+    "load_order": ["aliases.sh"]
+  },
+  "install": {
+    "macos": { "brew": ["terraform"] },
+    "linux": { "apt": ["terraform"] },
+    "wsl": { "inherit": "linux" }
+  }
+}

--- a/modules/tmux/module.json
+++ b/modules/tmux/module.json
@@ -1,0 +1,16 @@
+{
+  "name": "tmux",
+  "version": "1.0.0",
+  "description": "Tmux terminal multiplexer configuration",
+  "sections": {
+    "tmux.config": "Tmux configuration symlinks"
+  },
+  "install": {
+    "macos": { "brew": ["tmux"] },
+    "linux": { "apt": ["tmux"] },
+    "wsl": { "inherit": "linux" }
+  },
+  "symlinks": {
+    "config/.tmux.conf": "~/.tmux.conf"
+  }
+}

--- a/modules/vim/module.json
+++ b/modules/vim/module.json
@@ -1,0 +1,16 @@
+{
+  "name": "vim",
+  "version": "1.0.0",
+  "description": "Vim/Neovim configuration",
+  "sections": {
+    "vim.config": "Vim configuration symlinks"
+  },
+  "install": {
+    "macos": { "brew": ["neovim"] },
+    "linux": { "apt": ["neovim"] },
+    "wsl": { "inherit": "linux" }
+  },
+  "symlinks": {
+    "config/.vimrc": "~/.vimrc"
+  }
+}


### PR DESCRIPTION
## Summary
12 modules extracted from the reference dotfiles:

| Module | Sections |
|---|---|
| python | core, venv |
| node | npm, scripts |
| rust | cargo (with ~/.cargo/bin PATH) |
| vim | config (symlink) |
| tmux | config (symlink) |
| fzf | core (options/commands), keybindings |
| terraform | core (with OpenTofu fallback) |
| navigation | dirs, bookmarks |
| safety | disk usage helpers |
| network | ip/connectivity, http/certs |
| security | ssh management, gpg management, genpass |
| system | sysinfo, processes, calc |

All modules have `module.json` with sections and `dotfiles_section()` guards.

Closes #18